### PR TITLE
Add dual schedule tool with drag transfer

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -48,7 +48,12 @@ export function init() {
       data TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
     );
-        CREATE TABLE IF NOT EXISTS schedule_trips_tool (
+    CREATE TABLE IF NOT EXISTS schedule_trips_tool (
+      id TEXT PRIMARY KEY,
+      data TEXT,
+      created_at TEXT DEFAULT CURRENT_TIMESTAMP
+    );
+    CREATE TABLE IF NOT EXISTS schedule_trips_tool2 (
       id TEXT PRIMARY KEY,
       data TEXT,
       created_at TEXT DEFAULT CURRENT_TIMESTAMP
@@ -178,6 +183,7 @@ export function init() {
     'drivers_report',
     'schedule_trips',
     'schedule_trips_tool',
+    'schedule_trips_tool2',
     'csv_trips',
     'van_checks',
     'users',

--- a/pages/api/schedule-tool2.ts
+++ b/pages/api/schedule-tool2.ts
@@ -1,0 +1,55 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import db from '../../lib/db';
+
+export const config = {
+    api: {
+        bodyParser: {
+            sizeLimit: '50mb',
+        },
+    },
+};
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+    try {
+        if (req.method === 'GET') {
+            const rows = db.prepare('SELECT data FROM schedule_trips_tool2').all();
+            const items = rows.map((r: any) => JSON.parse(r.data));
+            return res.status(200).json(items);
+        }
+
+        if (req.method === 'DELETE') {
+            db.exec('DELETE FROM schedule_trips_tool2');
+            return res.status(200).json({ message: 'Cleared' });
+        }
+
+        if (req.method === 'POST') {
+            const payload = req.body;
+            let trips: any[] = [];
+            if (Array.isArray(payload)) trips = payload;
+            else if (Array.isArray(payload.trips)) trips = payload.trips;
+            else if (Array.isArray(payload.Schedule_Trips)) trips = payload.Schedule_Trips;
+            else if (Array.isArray(payload.schedule_trips)) trips = payload.schedule_trips;
+            else if (Array.isArray(payload.scheduleTrips)) trips = payload.scheduleTrips;
+            if (!Array.isArray(trips)) {
+                return res.status(400).json({ message: 'No schedule trips found' });
+            }
+
+            const del = db.prepare('DELETE FROM schedule_trips_tool2');
+            del.run();
+            const stmt = db.prepare(
+                "INSERT INTO schedule_trips_tool2 (id, data, created_at) VALUES (?, ?, datetime('now'))",
+            );
+            for (const item of trips) {
+                const id = item.ID || item.id;
+                if (!id) continue;
+                stmt.run(id, JSON.stringify(item));
+            }
+            return res.status(200).json({ message: 'Saved' });
+        }
+
+        return res.status(405).json({ message: 'Method not allowed' });
+    } catch (err) {
+        console.error(err);
+        return res.status(500).json({ message: 'Server error' });
+    }
+}


### PR DESCRIPTION
## Summary
- add new DB table `schedule_trips_tool2`
- expose API endpoint for second schedule table
- show left and right schedule tables with upload areas
- allow dragging driver names across the two tables

## Testing
- `npm run build` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_688a11e2f78c8324b0926ccc4e80b510