### PR TITLE
Refactor schedule tool tables

### DIFF
--- a/components/schedule/ScheduleTable.tsx
+++ b/components/schedule/ScheduleTable.tsx
@@ -1,52 +1,46 @@
-import { Trip } from '../../hooks/useScheduleData';
-import { RouteGroup } from '../../hooks/useScheduleSettings';
-import { getRouteColorClass } from '../../lib/scheduleUtils';
 import React from 'react';
+import { Trip } from '../../hooks/useScheduleData';
+import { SortConfig } from '../../lib/scheduleUtils';
 
-export interface SortConfig {
+export interface ColumnConfig {
   key: string;
-  dir: 'asc' | 'desc';
+  label: string;
+  className?: (item: Trip) => string;
 }
 
 interface Props {
   items: Trip[];
+  columns: ColumnConfig[];
   sortConfig: SortConfig | null;
   onSort: (key: string) => void;
   selectedRows: number[];
   onRowMouseDown: (index: number) => void;
   onRowMouseOver: (index: number) => void;
   onRowMouseUp: () => void;
-  routeGroups?: RouteGroup[];
 }
-
-const headers = [
-  { key: 'Driver1', label: 'Driver' },
-  { key: 'Start_Time', label: 'Start' },
-  { key: 'End_Time', label: 'End' },
-];
 
 const ScheduleTable: React.FC<Props> = ({
   items,
+  columns,
   sortConfig,
   onSort,
   selectedRows,
   onRowMouseDown,
   onRowMouseOver,
   onRowMouseUp,
-  routeGroups = [],
 }) => {
   return (
     <table className="min-w-full text-sm border-collapse">
       <thead>
         <tr>
-          {headers.map(h => (
+          {columns.map(col => (
             <th
-              key={h.key}
+              key={col.key}
               className="p-2 cursor-pointer border-b"
-              onClick={() => onSort(h.key)}
+              onClick={() => onSort(col.key)}
             >
-              {h.label}
-              {sortConfig?.key === h.key && (sortConfig.dir === 'asc' ? ' ▲' : ' ▼')}
+              {col.label}
+              {sortConfig?.key === col.key && (sortConfig.dir === 'asc' ? ' ▲' : ' ▼')}
             </th>
           ))}
         </tr>
@@ -60,9 +54,14 @@ const ScheduleTable: React.FC<Props> = ({
             onMouseUp={onRowMouseUp}
             className={`border-b ${selectedRows.includes(idx) ? 'bg-blue-100 dark:bg-blue-900/40' : ''}`}
           >
-            <td className="p-2">{item.Driver1 || ''}</td>
-            <td className="p-2">{item.Start_Time || ''}</td>
-            <td className={`p-2 ${getRouteColorClass(routeGroups, item.Calendar_Name)}`}>{item.End_Time || ''}</td>
+            {columns.map(col => (
+              <td
+                key={col.key}
+                className={`p-2 ${col.className ? col.className(item) : ''}`}
+              >
+                {(item as any)[col.key] || ''}
+              </td>
+            ))}
           </tr>
         ))}
       </tbody>

--- a/lib/scheduleUtils.ts
+++ b/lib/scheduleUtils.ts
@@ -1,6 +1,11 @@
 import { Trip } from '../hooks/useScheduleData';
 import { RouteGroup } from '../hooks/useScheduleSettings';
 
+export interface SortConfig {
+  key: string;
+  dir: 'asc' | 'desc';
+}
+
 export function getRouteColorClass(routeGroups: RouteGroup[], calendarName?: string) {
   if (!calendarName) return '';
   const code = calendarName.split(/\s+/)[0].toUpperCase();
@@ -32,4 +37,17 @@ export function computeStats(trips: Trip[]) {
   const total = trips.length;
   const assigned = trips.filter(t => t.isAssigned).length;
   return { total, assigned };
+}
+
+export function getNextSort(current: SortConfig | null, key: string): SortConfig {
+  const dir = current?.key === key && current.dir === 'asc' ? 'desc' : 'asc';
+  return { key, dir };
+}
+
+export function sortTrips(trips: Trip[], key: string, dir: 'asc' | 'desc'): Trip[] {
+  return [...trips].sort((a: any, b: any) => {
+    const av = (a[key] ?? '') as string;
+    const bv = (b[key] ?? '') as string;
+    return av.localeCompare(bv) * (dir === 'asc' ? 1 : -1);
+  });
 }


### PR DESCRIPTION
## Summary
- centralize schedule sorting helpers
- render schedule tables from configurable columns
- use shared table component in schedule tool page

## Testing
- `npm run build` *(fails: Type error in components/OrderDetailModal.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6894724b40fc8324916959a443f756dc