### PR TITLE
feat: unify start time component and add driver control nav

### DIFF
--- a/components/StartTime.tsx
+++ b/components/StartTime.tsx
@@ -1,0 +1,231 @@
+import { Dispatch, SetStateAction } from 'react';
+import Icon from './Icon';
+
+export interface StartTimeFilters {
+  start: string;
+  end: string;
+  startSearch: string;
+  startContractor: string;
+}
+
+export type StartTimeFilterAction =
+  | { type: 'SET_FILTER'; key: keyof StartTimeFilters; value: string }
+  | { type: 'SET_DATE_RANGE'; start: string; end: string }
+  | { type: 'RESET' };
+
+export const calcLoad = (startTime: string) => {
+  if (!startTime?.includes(':')) return 'N/A';
+  const [h, m] = startTime.trim().split(':').map(Number);
+  if (isNaN(h) || isNaN(m)) return 'N/A';
+  const date = new Date();
+  date.setHours(h, m, 0, 0);
+  date.setMinutes(date.getMinutes() - 90);
+  return date.toLocaleTimeString('en-GB', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+};
+
+export const diffTime = (t1: string, t2: string) => {
+  if (!t1 || !t2) return 'N/A';
+  const [h1, m1] = t1.split(':').map(Number);
+  const [h2, m2] = t2.split(':').map(Number);
+  if ([h1, m1, h2, m2].some((n) => isNaN(n))) return 'N/A';
+  const minutes1 = h1 * 60 + m1;
+  const minutes2 = h2 * 60 + m2;
+  let diff = minutes2 - minutes1;
+  if (diff > 12 * 60) diff -= 24 * 60;
+  if (diff < -12 * 60) diff += 24 * 60;
+  return diff.toString();
+};
+
+interface StartTimeProps {
+  startData: any[];
+  filters: StartTimeFilters;
+  dispatchFilters: Dispatch<StartTimeFilterAction>;
+  startSortField:
+    | 'Asset'
+    | 'Contractor_Name'
+    | 'Driver'
+    | 'First_Mention_Time'
+    | 'Start_Time'
+    | 'Last_Mention_Time';
+  startSortDir: 'asc' | 'desc';
+  setStartSortField: (field: StartTimeProps['startSortField']) => void;
+  setStartSortDir: Dispatch<SetStateAction<'asc' | 'desc'>>;
+  startContractors: string[];
+  copyStartTable: () => void;
+  downloadStartCSV: () => void;
+  showDateRange?: boolean;
+}
+
+export default function StartTime({
+  startData,
+  filters,
+  dispatchFilters,
+  startSortField,
+  setStartSortField,
+  startSortDir,
+  setStartSortDir,
+  startContractors,
+  copyStartTable,
+  downloadStartCSV,
+  showDateRange = false,
+}: StartTimeProps) {
+  return (
+    <div className="space-y-6">
+      {showDateRange && (
+        <div className="flex items-center gap-2 mb-4">
+          <input
+            type="date"
+            value={filters.start}
+            onChange={(e) =>
+              dispatchFilters({
+                type: 'SET_FILTER',
+                key: 'start',
+                value: e.target.value,
+              })
+            }
+            className="input input-bordered input-sm"
+          />
+          <input
+            type="date"
+            value={filters.end}
+            onChange={(e) =>
+              dispatchFilters({
+                type: 'SET_FILTER',
+                key: 'end',
+                value: e.target.value,
+              })
+            }
+            className="input input-bordered input-sm"
+          />
+          <button
+            onClick={() => dispatchFilters({ type: 'RESET' })}
+            className="btn btn-sm"
+          >
+            Reset
+          </button>
+        </div>
+      )}
+
+      <div className="flex justify-between items-center mb-2">
+        <h2 className="text-lg font-bold">Start Times Analysis</h2>
+        <div className="flex gap-2">
+          <input
+            type="text"
+            placeholder="Search..."
+            value={filters.startSearch}
+            onChange={(e) =>
+              dispatchFilters({
+                type: 'SET_FILTER',
+                key: 'startSearch',
+                value: e.target.value,
+              })
+            }
+            className="input input-bordered input-xs w-28"
+          />
+          <select
+            value={filters.startContractor}
+            onChange={(e) =>
+              dispatchFilters({
+                type: 'SET_FILTER',
+                key: 'startContractor',
+                value: e.target.value,
+              })
+            }
+            className="select select-bordered select-xs w-32"
+          >
+            <option value="">All Contractors</option>
+            {startContractors.map((c) => (
+              <option key={c} value={c}>
+                {c}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={copyStartTable}
+            className="btn btn-xs btn-ghost"
+            title="Copy"
+          >
+            <Icon name="copy" className="w-3 h-3" />
+          </button>
+          <button
+            onClick={downloadStartCSV}
+            className="btn btn-xs btn-ghost"
+            title="Download"
+          >
+            <Icon name="download" className="w-3 h-3" />
+          </button>
+        </div>
+      </div>
+
+      <div className="overflow-auto">
+        <table className="table table-xs table-zebra">
+          <thead className="sticky top-0 bg-base-100 z-10">
+            <tr>
+              {[
+                ['Asset', 'Asset'],
+                ['Contractor', 'Contractor_Name'],
+                ['Driver', 'Driver'],
+                ['Arrive WH', 'First_Mention_Time'],
+                ['Load Time', 'load'],
+                ['Diff Load', 'diffLoad'],
+                ['Start Time', 'Start_Time'],
+                ['Left WH', 'Last_Mention_Time'],
+                ['Diff Start', 'diffStart'],
+              ].map(([label, field]) => (
+                <th
+                  key={field}
+                  className="cursor-pointer select-none"
+                  onClick={() => {
+                    if (
+                      field === 'load' ||
+                      field === 'diffLoad' ||
+                      field === 'diffStart'
+                    )
+                      return;
+                    setStartSortField(field as any);
+                    setStartSortDir((prev) =>
+                      startSortField === field
+                        ? prev === 'asc'
+                          ? 'desc'
+                          : 'asc'
+                        : 'asc'
+                    );
+                  }}
+                >
+                  {label}
+                  {startSortField === field && (
+                    <span>{startSortDir === 'asc' ? ' ▲' : ' ▼'}</span>
+                  )}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {startData.map((r, idx) => {
+              const load = calcLoad(r.Start_Time);
+              const diffLoad = diffTime(r.First_Mention_Time, load);
+              const diffStart = diffTime(r.Last_Mention_Time, r.Start_Time);
+              return (
+                <tr key={idx} className="hover">
+                  <td className="font-medium">{r.Asset}</td>
+                  <td>{r.Contractor_Name}</td>
+                  <td>{r.Driver}</td>
+                  <td>{r.First_Mention_Time}</td>
+                  <td className="text-info">{load}</td>
+                  <td className={Math.abs(parseInt(diffLoad)) > 15 ? 'text-warning' : ''}>{diffLoad}</td>
+                  <td className="font-medium">{r.Start_Time}</td>
+                  <td>{r.Last_Mention_Time}</td>
+                  <td className={Math.abs(parseInt(diffStart)) > 15 ? 'text-warning' : ''}>{diffStart}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+

--- a/pages/driver-routes.tsx
+++ b/pages/driver-routes.tsx
@@ -6,6 +6,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { debounce } from 'lodash';
 import { parseDate } from '../lib/dateUtils';
 import { parseTimeToMinutes } from '../lib/timeUtils';
+import DCNavbar from '../components/DCNavbar';
 
 interface Item {
   driver: string;
@@ -503,7 +504,8 @@ export default function DriverRoutes() {
   const handleDrag = (e: DragEvent<HTMLDivElement>) => e.preventDefault();
 
   return (
-    <Layout title="Driver Routes" fullWidth>
+    <Layout title="Driver Routes" fullWidth hideNavbar>
+      <DCNavbar />
       <div className="flex flex-col h-full p-4 gap-4">
         {/* Error message */}
         <AnimatePresence>

--- a/pages/full-report.tsx
+++ b/pages/full-report.tsx
@@ -20,6 +20,7 @@ import FailedReasonsCard from "../components/FailedReasonsCard";
 import FailureAnalysisModal from "../components/FailureAnalysisModal";
 import { getFailureReason } from "../lib/failureReason";
 import { parseDate } from "../lib/dateUtils";
+import StartTimeSection, { calcLoad, diffTime } from "../components/StartTime";
 
 // --- Helpers ---
 interface Trip {
@@ -29,31 +30,6 @@ interface Trip {
 
 const formatDate = (date: Date) => date.toISOString().slice(0, 10);
 
-const calcLoad = (startTime: string) => {
-  if (!startTime?.includes(":")) return "N/A";
-  const [h, m] = startTime.trim().split(":").map(Number);
-  if (isNaN(h) || isNaN(m)) return "N/A";
-  const date = new Date();
-  date.setHours(h, m, 0, 0);
-  date.setMinutes(date.getMinutes() - 90);
-  return date.toLocaleTimeString("en-GB", {
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-};
-
-const diffTime = (t1: string, t2: string) => {
-  if (!t1 || !t2) return "N/A";
-  const [h1, m1] = t1.split(":").map(Number);
-  const [h2, m2] = t2.split(":").map(Number);
-  if ([h1, m1, h2, m2].some((n) => isNaN(n))) return "N/A";
-  const minutes1 = h1 * 60 + m1;
-  const minutes2 = h2 * 60 + m2;
-  let diff = minutes2 - minutes1;
-  if (diff > 12 * 60) diff -= 24 * 60;
-  if (diff < -12 * 60) diff += 24 * 60;
-  return diff.toString();
-};
 
 // --- Filter state management ---
 interface Filters {
@@ -706,141 +682,18 @@ export default function FullReport() {
           <div className="p-3 grid grid-cols-1 lg:grid-cols-12 gap-3">
             {/* Start Times - Takes 5 columns */}
             <div className="lg:col-span-5 bg-base-100 rounded-lg shadow-lg p-3">
-              <div className="flex justify-between items-center mb-2">
-                <h2 className="text-lg font-bold">Start Times Analysis</h2>
-                <div className="flex gap-2">
-                  <input
-                    type="text"
-                    placeholder="Search..."
-                    value={filters.startSearch}
-                    onChange={(e) =>
-                      dispatchFilters({
-                        type: "SET_FILTER",
-                        key: "startSearch",
-                        value: e.target.value,
-                      })
-                    }
-                    className="input input-bordered input-xs w-28"
-                  />
-                  <select
-                    value={filters.startContractor}
-                    onChange={(e) =>
-                      dispatchFilters({
-                        type: "SET_FILTER",
-                        key: "startContractor",
-                        value: e.target.value,
-                      })
-                    }
-                    className="select select-bordered select-xs w-32"
-                  >
-                    <option value="">All Contractors</option>
-                    {startContractors.map((c) => (
-                      <option key={c} value={c}>
-                        {c}
-                      </option>
-                    ))}
-                  </select>
-                  <button
-                    onClick={copyStartTable}
-                    className="btn btn-xs btn-ghost"
-                    title="Copy"
-                  >
-                    <Icon name="copy" className="w-3 h-3" />
-                  </button>
-                  <button
-                    onClick={downloadStartCSV}
-                    className="btn btn-xs btn-ghost"
-                    title="Download"
-                  >
-                    <Icon name="download" className="w-3 h-3" />
-                  </button>
-                </div>
-              </div>
-
-              <div className="overflow-auto max-h-[calc(100vh-220px)]">
-                <table className="table table-xs table-zebra">
-                  <thead className="sticky top-0 bg-base-100 z-10">
-                    <tr>
-                      {[
-                        ["Asset", "Asset"],
-                        ["Contractor", "Contractor_Name"],
-                        ["Driver", "Driver"],
-                        ["Arrive WH", "First_Mention_Time"],
-                        ["Load Time", "load"],
-                        ["Diff Load", "diffLoad"],
-                        ["Start Time", "Start_Time"],
-                        ["Left WH", "Last_Mention_Time"],
-                        ["Diff Start", "diffStart"],
-                      ].map(([label, field]) => (
-                        <th
-                          key={field}
-                          className="cursor-pointer select-none"
-                          onClick={() => {
-                            if (
-                              field === "load" ||
-                              field === "diffLoad" ||
-                              field === "diffStart"
-                            )
-                              return;
-                            setStartSortField(field as any);
-                            setStartSortDir((prev) =>
-                              startSortField === field
-                                ? prev === "asc"
-                                  ? "desc"
-                                  : "asc"
-                                : "asc",
-                            );
-                          }}
-                        >
-                          {label}
-                          {startSortField === field && (
-                            <span>{startSortDir === "asc" ? " ▲" : " ▼"}</span>
-                          )}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {startData.map((r, idx) => {
-                      const load = calcLoad(r.Start_Time);
-                      const diffLoad = diffTime(r.First_Mention_Time, load);
-                      const diffStart = diffTime(
-                        r.Last_Mention_Time,
-                        r.Start_Time,
-                      );
-                      return (
-                        <tr key={idx} className="hover">
-                          <td className="font-medium">{r.Asset}</td>
-                          <td>{r.Contractor_Name}</td>
-                          <td>{r.Driver}</td>
-                          <td>{r.First_Mention_Time}</td>
-                          <td className="text-info">{load}</td>
-                          <td
-                            className={
-                              Math.abs(parseInt(diffLoad)) > 15
-                                ? "text-warning"
-                                : ""
-                            }
-                          >
-                            {diffLoad}
-                          </td>
-                          <td className="font-medium">{r.Start_Time}</td>
-                          <td>{r.Last_Mention_Time}</td>
-                          <td
-                            className={
-                              Math.abs(parseInt(diffStart)) > 15
-                                ? "text-warning"
-                                : ""
-                            }
-                          >
-                            {diffStart}
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </tbody>
-                </table>
-              </div>
+              <StartTimeSection
+                startData={startData}
+                filters={filters}
+                dispatchFilters={dispatchFilters}
+                startSortField={startSortField}
+                setStartSortField={setStartSortField}
+                startSortDir={startSortDir}
+                setStartSortDir={setStartSortDir}
+                startContractors={startContractors}
+                copyStartTable={copyStartTable}
+                downloadStartCSV={downloadStartCSV}
+              />
             </div>
 
             {/* Van Checks - Takes 3 columns */}

--- a/pages/schedule-tool.tsx
+++ b/pages/schedule-tool.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, DragEvent, ChangeEvent, useRef, KeyboardEvent, use
 import Layout from '../components/Layout';
 import Icon from '../components/Icon';
 import Modal from '../components/Modal';
+import DCNavbar from '../components/DCNavbar';
 import { parseTimeToMinutes } from '../lib/timeUtils';
 interface Trip {
     ID: string;
@@ -911,7 +912,8 @@ export default function ScheduleTool() {
         setLockedRight(newSet);
     };
     return (
-        <Layout title="Schedule Tool" fullWidth>
+        <Layout title="Schedule Tool" fullWidth hideNavbar>
+            <DCNavbar />
             <div className="flex gap-2 w-full h-[calc(100vh-4.5rem)] bg-base-100 dark:bg-base-100">
                 {/* Left Table */}
                 <div className="flex-1 min-w-0 flex flex-col border-r border-gray-200 dark:border-gray-700 relative" onMouseUp={handleMouseUpLeft} onDragOver={(e) => e.preventDefault()} onDrop={handleLeftDrop}>

--- a/pages/start-time.tsx
+++ b/pages/start-time.tsx
@@ -1,28 +1,25 @@
 import { useState, useEffect, useMemo, useCallback, useReducer } from 'react';
 import useSWR from 'swr';
 import Layout from '../components/Layout';
-import Icon from '../components/Icon';
+import DCNavbar from '../components/DCNavbar';
+import StartTime, {
+  StartTimeFilters,
+  StartTimeFilterAction,
+  calcLoad,
+  diffTime,
+} from '../components/StartTime';
 
-interface Filters {
-  start: string;
-  end: string;
-  startSearch: string;
-  startContractor: string;
-}
-
-type FilterAction =
-  | { type: 'SET_FILTER'; key: keyof Filters; value: string }
-  | { type: 'SET_DATE_RANGE'; start: string; end: string }
-  | { type: 'RESET' };
-
-const initialFilters: Filters = {
+const initialFilters: StartTimeFilters = {
   start: '',
   end: '',
   startSearch: '',
   startContractor: '',
 };
 
-function filterReducer(state: Filters, action: FilterAction): Filters {
+function filterReducer(
+  state: StartTimeFilters,
+  action: StartTimeFilterAction,
+): StartTimeFilters {
   switch (action.type) {
     case 'SET_FILTER':
       return { ...state, [action.key]: action.value };
@@ -36,29 +33,6 @@ function filterReducer(state: Filters, action: FilterAction): Filters {
 }
 
 const formatDate = (date: Date) => date.toISOString().slice(0, 10);
-
-const calcLoad = (startTime: string) => {
-  if (!startTime?.includes(':')) return 'N/A';
-  const [h, m] = startTime.trim().split(':').map(Number);
-  if (isNaN(h) || isNaN(m)) return 'N/A';
-  const date = new Date();
-  date.setHours(h, m, 0, 0);
-  date.setMinutes(date.getMinutes() - 90);
-  return date.toLocaleTimeString('en-GB', { hour: '2-digit', minute: '2-digit' });
-};
-
-const diffTime = (t1: string, t2: string) => {
-  if (!t1 || !t2) return 'N/A';
-  const [h1, m1] = t1.split(':').map(Number);
-  const [h2, m2] = t2.split(':').map(Number);
-  if ([h1, m1, h2, m2].some((n) => isNaN(n))) return 'N/A';
-  const minutes1 = h1 * 60 + m1;
-  const minutes2 = h2 * 60 + m2;
-  let diff = minutes2 - minutes1;
-  if (diff > 12 * 60) diff -= 24 * 60;
-  if (diff < -12 * 60) diff += 24 * 60;
-  return diff.toString();
-};
 
 export default function StartTimePage() {
   const today = useMemo(() => formatDate(new Date()), []);
@@ -121,23 +95,14 @@ export default function StartTimePage() {
         r.Start_Time,
         r.Last_Mention_Time,
         diffStart,
-      ].join(',');
+      ].join('\t');
     });
-    navigator.clipboard.writeText(rows.join('\n'));
+    const header =
+      'Asset\tContractor\tDriver\tArrive WH\tLoad Time\tDiff Load\tStart Time\tLeft WH\tDiff Start';
+    navigator.clipboard.writeText([header, ...rows].join('\n'));
   }, [startData]);
 
   const downloadStartCSV = useCallback(() => {
-    const header = [
-      'Asset',
-      'Contractor',
-      'Driver',
-      'Arrive WH',
-      'Load Time',
-      'Diff Load',
-      'Start Time',
-      'Left WH',
-      'Diff Start',
-    ];
     const rows = startData.map((r) => {
       const load = calcLoad(r.Start_Time);
       const diffLoad = diffTime(r.First_Mention_Time, load);
@@ -152,9 +117,20 @@ export default function StartTimePage() {
         r.Start_Time,
         r.Last_Mention_Time,
         diffStart,
-      ].join(',');
+      ];
     });
-    const csv = [header.join(','), ...rows].join('\n');
+    const header = [
+      'Asset',
+      'Contractor',
+      'Driver',
+      'Arrive WH',
+      'Load Time',
+      'Diff Load',
+      'Start Time',
+      'Left WH',
+      'Diff Start',
+    ];
+    const csv = [header, ...rows].map((r) => r.join(',')).join('\n');
     const blob = new Blob([csv], { type: 'text/csv' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -165,132 +141,22 @@ export default function StartTimePage() {
   }, [startData]);
 
   return (
-    <Layout title="Start Times" fullWidth>
-      <div className="p-4">
-        <div className="mb-4 flex flex-wrap items-center gap-2">
-          <input
-            type="date"
-            value={filters.start}
-            onChange={(e) =>
-              dispatchFilters({ type: 'SET_FILTER', key: 'start', value: e.target.value })
-            }
-            className="input input-bordered input-sm"
-          />
-          <input
-            type="date"
-            value={filters.end}
-            onChange={(e) =>
-              dispatchFilters({ type: 'SET_FILTER', key: 'end', value: e.target.value })
-            }
-            className="input input-bordered input-sm"
-          />
-          <button onClick={() => dispatchFilters({ type: 'RESET' })} className="btn btn-sm">
-            Reset
-          </button>
-        </div>
-
-        <div className="flex justify-between items-center mb-2">
-          <h2 className="text-lg font-bold">Start Times Analysis</h2>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              placeholder="Search..."
-              value={filters.startSearch}
-              onChange={(e) =>
-                dispatchFilters({
-                  type: 'SET_FILTER',
-                  key: 'startSearch',
-                  value: e.target.value,
-                })
-              }
-              className="input input-bordered input-xs w-28"
-            />
-            <select
-              value={filters.startContractor}
-              onChange={(e) =>
-                dispatchFilters({
-                  type: 'SET_FILTER',
-                  key: 'startContractor',
-                  value: e.target.value,
-                })
-              }
-              className="select select-bordered select-xs w-32"
-            >
-              <option value="">All Contractors</option>
-              {startContractors.map((c) => (
-                <option key={c} value={c}>
-                  {c}
-                </option>
-              ))}
-            </select>
-            <button onClick={copyStartTable} className="btn btn-xs btn-ghost" title="Copy">
-              <Icon name="copy" className="w-3 h-3" />
-            </button>
-            <button
-              onClick={downloadStartCSV}
-              className="btn btn-xs btn-ghost"
-              title="Download"
-            >
-              <Icon name="download" className="w-3 h-3" />
-            </button>
-          </div>
-        </div>
-
-        <div className="overflow-auto">
-          <table className="table table-xs table-zebra">
-            <thead className="sticky top-0 bg-base-100 z-10">
-              <tr>
-                {[
-                  ['Asset', 'Asset'],
-                  ['Contractor', 'Contractor_Name'],
-                  ['Driver', 'Driver'],
-                  ['Arrive WH', 'First_Mention_Time'],
-                  ['Load Time', 'load'],
-                  ['Diff Load', 'diffLoad'],
-                  ['Start Time', 'Start_Time'],
-                  ['Left WH', 'Last_Mention_Time'],
-                  ['Diff Start', 'diffStart'],
-                ].map(([label, field]) => (
-                  <th
-                    key={field}
-                    className="cursor-pointer select-none"
-                    onClick={() => {
-                      if (field === 'load' || field === 'diffLoad' || field === 'diffStart') return;
-                      setStartSortField(field as any);
-                      setStartSortDir((prev) =>
-                        startSortField === field ? (prev === 'asc' ? 'desc' : 'asc') : 'asc',
-                      );
-                    }}
-                  >
-                    {label}
-                    {startSortField === field && <span>{startSortDir === 'asc' ? ' ▲' : ' ▼'}</span>}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {startData.map((r, idx) => {
-                const load = calcLoad(r.Start_Time);
-                const diffLoad = diffTime(r.First_Mention_Time, load);
-                const diffStart = diffTime(r.Last_Mention_Time, r.Start_Time);
-                return (
-                  <tr key={idx} className="hover">
-                    <td className="font-medium">{r.Asset}</td>
-                    <td>{r.Contractor_Name}</td>
-                    <td>{r.Driver}</td>
-                    <td>{r.First_Mention_Time}</td>
-                    <td className="text-info">{load}</td>
-                    <td className={Math.abs(parseInt(diffLoad)) > 15 ? 'text-warning' : ''}>{diffLoad}</td>
-                    <td className="font-medium">{r.Start_Time}</td>
-                    <td>{r.Last_Mention_Time}</td>
-                    <td className={Math.abs(parseInt(diffStart)) > 15 ? 'text-warning' : ''}>{diffStart}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-      </div>
+    <Layout title="Start Time" hideNavbar fullWidth>
+      <DCNavbar />
+      <StartTime
+        startData={startData}
+        filters={filters}
+        dispatchFilters={dispatchFilters}
+        startSortField={startSortField}
+        setStartSortField={setStartSortField}
+        startSortDir={startSortDir}
+        setStartSortDir={setStartSortDir}
+        startContractors={startContractors}
+        copyStartTable={copyStartTable}
+        downloadStartCSV={downloadStartCSV}
+        showDateRange
+      />
     </Layout>
   );
 }
+

--- a/pages/upload.tsx
+++ b/pages/upload.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, DragEvent, ChangeEvent } from 'react';
 import Layout from '../components/Layout';
 import Icon from '../components/Icon';
 import UploadHistory from '../components/UploadHistory';
+import DCNavbar from '../components/DCNavbar';
 
 export default function Upload() {
   const [files, setFiles] = useState<File[]>([]);
@@ -117,7 +118,8 @@ export default function Upload() {
   };
 
   return (
-    <Layout title="Upload Files">
+    <Layout title="Upload Files" hideNavbar fullWidth>
+      <DCNavbar />
       <h1 className="text-2xl font-bold mb-4">Upload Files</h1>
       <div
         className="border-2 border-dashed rounded-lg p-6 text-center bg-white dark:bg-gray-700 dark:border-gray-500 dark:text-gray-200 cursor-pointer"

--- a/pages/working-times.tsx
+++ b/pages/working-times.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Layout from '../components/Layout';
 import AnalogClock from '../components/AnalogClock';
+import DCNavbar from '../components/DCNavbar';
 
 function weekNumber(dateStr: string): number {
   const d = new Date(dateStr);
@@ -116,7 +117,8 @@ export default function WorkingTimes() {
   }, []);
 
   return (
-    <Layout title="Working Times" fullWidth>
+    <Layout title="Working Times" fullWidth hideNavbar>
+      <DCNavbar />
       <div className="space-y-6">
         <div className="flex items-center justify-between">
           <h1 className="text-3xl font-bold text-gray-900 dark:text-white">Working Times</h1>


### PR DESCRIPTION
## Summary
- extract start time analysis into reusable component
- add Driver Control navigation bar across driver tools

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Type error in components/OrderDetailModal.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6894878b92408324952c3b872fc20c25