### PR TITLE
Refactor schedule tool into modular components

### DIFF
--- a/components/ScheduleNotesSidebar.tsx
+++ b/components/ScheduleNotesSidebar.tsx
@@ -1,0 +1,132 @@
+import { DragEvent, ChangeEvent, Dispatch, SetStateAction } from 'react';
+import Icon from './Icon';
+
+interface Panel {
+    name: string;
+    color: string;
+    icon: string;
+}
+
+interface Props {
+    panels: Panel[];
+    notes: Record<string, string>;
+    handleNoteChange: (panel: string, value: string) => void;
+    clearNote: (panel: string) => void;
+    handleInputFile: (e: ChangeEvent<HTMLInputElement>) => void;
+    handleDropFile: (e: DragEvent<HTMLDivElement>) => void;
+    clearAllLeft: () => void;
+    clearAllRight: () => void;
+    lockCopy: boolean;
+    setLockCopy: (v: boolean) => void;
+    disableRowSelection: boolean;
+    setDisableRowSelection: (v: boolean) => void;
+    setSelectedLeft: Dispatch<SetStateAction<number[]>>;
+    setSelectedRight: Dispatch<SetStateAction<number[]>>;
+    setSettingsOpen: (v: boolean) => void;
+}
+
+export default function ScheduleNotesSidebar({
+    panels,
+    notes,
+    handleNoteChange,
+    clearNote,
+    handleInputFile,
+    handleDropFile,
+    clearAllLeft,
+    clearAllRight,
+    lockCopy,
+    setLockCopy,
+    disableRowSelection,
+    setDisableRowSelection,
+    setSelectedLeft,
+    setSelectedRight,
+    setSettingsOpen,
+}: Props) {
+    return (
+        <div className="w-64 flex flex-col gap-1 h-full overflow-y-auto p-1 bg-base-200 dark:bg-base-100 rounded-md shadow-inner lg:w-64 md:w-48 sm:w-full sm:overflow-x-auto">
+            <div className="flex flex-col gap-1 mb-1">
+                <div
+                    className="border border-dashed rounded p-1 text-center cursor-pointer bg-white dark:bg-gray-700 dark:border-gray-500 dark:text-gray-200"
+                    onDrop={handleDropFile}
+                    onDragOver={(e) => e.preventDefault()}
+                    onDragEnter={(e) => e.currentTarget.classList.add('bg-gray-900', 'dark:bg-gray-900/30')}
+                    onDragLeave={(e) => e.currentTarget.classList.remove('bg-gray-900', 'dark:bg-gray-900/30')}
+                >
+                    <input id="fileAll" type="file" accept=".json" onChange={handleInputFile} className="hidden" />
+                    <label htmlFor="fileAll" className="flex items-center justify-center gap-1 text-xs cursor-pointer">
+                        <Icon name="file-arrow-up" className="text-base" />
+                        Upload JSON
+                    </label>
+                </div>
+                <div className="flex flex-row gap-1 justify-center">
+                    <button
+                        onClick={() => {
+                            clearAllLeft();
+                            clearAllRight();
+                        }}
+                        className="btn btn-error btn-outline btn-xs flex items-center justify-center"
+                        title="Clear all data"
+                    >
+                        <Icon name="trash" className="w-3 h-3" />
+                    </button>
+                    <button
+                        className="btn btn-xs flex items-center justify-center"
+                        onClick={() => setLockCopy(!lockCopy)}
+                        title={lockCopy ? 'Unlock copy' : 'Lock copy'}
+                    >
+                        <Icon name={lockCopy ? 'lock' : 'unlock'} className="w-3 h-3" />
+                    </button>
+                    <button
+                        className="btn btn-xs flex items-center justify-center"
+                        onClick={() => {
+                            const newValue = !disableRowSelection;
+                            setDisableRowSelection(newValue);
+                            if (newValue) {
+                                setSelectedLeft([]);
+                                setSelectedRight([]);
+                            }
+                        }}
+                        title={disableRowSelection ? 'Unlock row selection' : 'Lock row selection'}
+                    >
+                        <Icon name={disableRowSelection ? 'lock' : 'unlock'} className="w-3 h-3" />
+                    </button>
+                    <button
+                        className="btn btn-xs flex items-center justify-center"
+                        onClick={() => setSettingsOpen(true)}
+                        title="Open settings"
+                    >
+                        <Icon name="gear" className="w-3 h-3" />
+                    </button>
+                </div>
+            </div>
+            <div className="text-sm font-semibold text-base-content mb-1">Notes</div>
+            <div className="flex flex-col gap-1">
+                {panels.map(panel => (
+                    <div key={panel.name} className={`card ${panel.color} shadow rounded-md overflow-hidden`}>
+                        <div className="p-1">
+                            <div className="flex items-center justify-between mb-0.5">
+                                <h3 className="text-xs font-medium flex items-center gap-1">
+                                    <Icon name={panel.icon} className="w-3 h-3" />
+                                    {panel.name}
+                                </h3>
+                                <button
+                                    onClick={() => clearNote(panel.name)}
+                                    className="btn btn-ghost btn-xs p-0 min-h-0 h-3 w-3 opacity-60 hover:opacity-100"
+                                    title="Clear note"
+                                >
+                                    ✕
+                                </button>
+                            </div>
+                            <textarea
+                                className="textarea w-full text-xs bg-white dark:bg-base-100 border border-gray-300 dark:border-gray-600 p-1 rounded resize-none h-24 overflow-y-auto focus:outline-none focus:border-blue-500"
+                                placeholder={`Notes for ${panel.name}...`}
+                                value={notes[panel.name] || ''}
+                                onChange={(e) => handleNoteChange(panel.name, e.target.value)}
+                            />
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/components/ScheduleSelectedStats.tsx
+++ b/components/ScheduleSelectedStats.tsx
@@ -1,0 +1,69 @@
+import Icon from './Icon';
+import { Trip } from '../types/schedule';
+
+interface Props {
+    selected: number[];
+    items: Trip[];
+    isLeft: boolean;
+    getTasks: (text?: string) => string;
+    getDuration: (it: Trip, isLeft: boolean) => number;
+    formatDuration: (minutes: number) => string;
+}
+
+export default function ScheduleSelectedStats({ selected, items, isLeft, getTasks, getDuration, formatDuration }: Props) {
+    if (selected.length <= 1) return null;
+    const selectedItems = items.filter((_, i) => selected.includes(i));
+    let totalTasks = 0, countTasks = 0, totalAmount = 0, countAmount = 0, totalPunct = 0, countPunct = 0, totalDuration = 0, countDuration = 0;
+    const uniqueDrivers = new Set(selectedItems.map(it => it.Driver1).filter(Boolean)).size;
+    selectedItems.forEach(it => {
+        const tasks = parseFloat(getTasks(it.Calendar_Name) || '0');
+        if (!isNaN(tasks)) {
+            totalTasks += tasks;
+            countTasks++;
+        }
+        const amount = parseFloat(it.Order_Value || '0');
+        if (!isNaN(amount)) {
+            totalAmount += amount;
+            countAmount++;
+        }
+        const punct = parseFloat(it.Punctuality || '0');
+        if (!isNaN(punct)) {
+            totalPunct += punct;
+            countPunct++;
+        }
+        const dur = getDuration(it, isLeft);
+        if (!isNaN(dur)) {
+            totalDuration += dur;
+            countDuration++;
+        }
+    });
+    const avgTasks = countTasks > 0 ? totalTasks / countTasks : 0;
+    const avgAmount = countAmount > 0 ? totalAmount / countAmount : 0;
+    const avgPunct = countPunct > 0 ? totalPunct / countPunct : 0;
+    const avgDuration = countDuration > 0 ? totalDuration / countDuration : 0;
+    const avgDurationFormatted = formatDuration(avgDuration);
+    return (
+        <div className="text-xs flex flex-wrap gap-1.5 items-center bg-gray-800 dark:bg-gray-900/80 p-1.5 rounded-lg shadow-md sticky bottom-0 z-10 border-t border-gray-700 dark:border-gray-600">
+            <span className="px-1.5 py-0.5 bg-gray-700 dark:bg-gray-800/50 rounded-md font-medium text-gray-200 dark:text-gray-300 flex items-center gap-1">
+                <Icon name="list-ul" className="w-3 h-3" />
+                {selected.length} ({uniqueDrivers})
+            </span>
+            <span className="px-1.5 py-0.5 bg-gray-700 dark:bg-gray-800/50 rounded-md font-medium text-gray-200 dark:text-gray-300 flex items-center gap-1">
+                <Icon name="check-square" className="w-3 h-3" />
+                {totalTasks.toFixed(2)} / {avgTasks.toFixed(2)}
+            </span>
+            <span className="px-1.5 py-0.5 bg-gray-700 dark:bg-gray-800/50 rounded-md font-medium text-gray-200 dark:text-gray-300 flex items-center gap-1">
+                <Icon name="currency-dollar" className="w-3 h-3" />
+                {totalAmount.toFixed(2)} / {avgAmount.toFixed(2)}
+            </span>
+            <span className="px-1.5 py-0.5 bg-gray-700 dark:bg-gray-800/50 rounded-md font-medium text-gray-200 dark:text-gray-300 flex items-center gap-1">
+                <Icon name="clock" className="w-3 h-3" />
+                {avgPunct.toFixed(2)}
+            </span>
+            <span className="px-1.5 py-0.5 bg-gray-700 dark:bg-gray-800/50 rounded-md font-medium text-gray-200 dark:text-gray-300 flex items-center gap-1">
+                <Icon name="hourglass" className="w-3 h-3" />
+                {avgDurationFormatted}
+            </span>
+        </div>
+    );
+}

--- a/components/ScheduleSettingsModal.tsx
+++ b/components/ScheduleSettingsModal.tsx
@@ -1,0 +1,186 @@
+import Modal from './Modal';
+import Icon from './Icon';
+import { RouteGroup, TimeSettings } from '../types/schedule';
+import { ChangeEvent } from 'react';
+
+interface Props {
+    open: boolean;
+    onClose: () => void;
+    routeGroups: RouteGroup[];
+    setRouteGroups: React.Dispatch<React.SetStateAction<RouteGroup[]>>;
+    updateGroup: (idx: number, group: RouteGroup) => void;
+    ignoredPatterns: string[];
+    setIgnoredPatterns: (patterns: string[]) => void;
+    timeSettings: TimeSettings;
+    setTimeSettings: React.Dispatch<React.SetStateAction<TimeSettings>>;
+    resetSettings: () => void;
+}
+
+export default function ScheduleSettingsModal({
+    open,
+    onClose,
+    routeGroups,
+    setRouteGroups,
+    updateGroup,
+    ignoredPatterns,
+    setIgnoredPatterns,
+    timeSettings,
+    setTimeSettings,
+    resetSettings,
+}: Props) {
+    const handlePatternChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+        setIgnoredPatterns(e.target.value.split('\n').map(p => p.trim()).filter(Boolean));
+    };
+
+    return (
+        <Modal open={open} onClose={onClose} className="max-w-4xl">
+            <h3 className="font-bold text-xl mb-4">Settings</h3>
+            <div className="space-y-4 max-h-[70vh] overflow-y-auto pr-2">
+                <section className="card bg-base-100 shadow p-4">
+                    <h4 className="card-title text-lg mb-2">Time Logic</h4>
+                    <div className="grid grid-cols-2 gap-2">
+                        <label className="flex items-center gap-2 text-sm">
+                            Late End Hour
+                            <input
+                                type="number"
+                                className="input input-bordered input-sm w-20"
+                                value={timeSettings.lateEndHour}
+                                onChange={(e) => setTimeSettings({ ...timeSettings, lateEndHour: parseInt(e.target.value) || 20 })}
+                                min={0}
+                                max={24}
+                            />
+                        </label>
+                        <label className="flex items-center gap-2 text-sm">
+                            Early Start Hour
+                            <input
+                                type="number"
+                                className="input input-bordered input-sm w-20"
+                                value={timeSettings.earlyStartHour}
+                                onChange={(e) => setTimeSettings({ ...timeSettings, earlyStartHour: parseInt(e.target.value) || 7 })}
+                                min={0}
+                                max={24}
+                            />
+                        </label>
+                        <label className="flex items-center gap-2 text-sm">
+                            Early End Hour
+                            <input
+                                type="number"
+                                className="input input-bordered input-sm w-20"
+                                value={timeSettings.earlyEndHour}
+                                onChange={(e) => setTimeSettings({ ...timeSettings, earlyEndHour: parseInt(e.target.value) || 17 })}
+                                min={0}
+                                max={24}
+                            />
+                        </label>
+                        <label className="flex items-center gap-2 text-sm">
+                            Late Start Hour
+                            <input
+                                type="number"
+                                className="input input-bordered input-sm w-20"
+                                value={timeSettings.lateStartHour}
+                                onChange={(e) => setTimeSettings({ ...timeSettings, lateStartHour: parseInt(e.target.value) || 9 })}
+                                min={0}
+                                max={24}
+                            />
+                        </label>
+                    </div>
+                    <div className="grid grid-cols-2 gap-2 mt-2">
+                        <label className="flex items-center gap-2 text-sm">
+                            <input
+                                type="checkbox"
+                                className="toggle toggle-sm"
+                                checked={timeSettings.enableRestWarning}
+                                onChange={(e) => setTimeSettings({ ...timeSettings, enableRestWarning: e.target.checked })}
+                            />
+                            Show Rest Warnings
+                        </label>
+                        <label className="flex items-center gap-2 text-sm">
+                            <input
+                                type="checkbox"
+                                className="toggle toggle-sm"
+                                checked={timeSettings.enableEarlyWarning}
+                                onChange={(e) => setTimeSettings({ ...timeSettings, enableEarlyWarning: e.target.checked })}
+                            />
+                            Show Early Warnings
+                        </label>
+                    </div>
+                    <input
+                        type="text"
+                        className="input input-bordered input-sm w-full mt-2"
+                        value={timeSettings.restMessage}
+                        onChange={(e) => setTimeSettings({ ...timeSettings, restMessage: e.target.value })}
+                        placeholder="Rest warning message"
+                    />
+                    <input
+                        type="text"
+                        className="input input-bordered input-sm w-full mt-2"
+                        value={timeSettings.earlyMessage}
+                        onChange={(e) => setTimeSettings({ ...timeSettings, earlyMessage: e.target.value })}
+                        placeholder="Early warning message"
+                    />
+                </section>
+                <section className="card bg-base-100 shadow p-4">
+                    <h4 className="card-title text-lg mb-2">Route Groups</h4>
+                    {routeGroups.map((group, idx) => (
+                        <div key={idx} className="border p-2 rounded-md mb-2 space-y-1">
+                            <div className="flex items-center gap-2">
+                                <input
+                                    className="input input-bordered input-xs flex-1"
+                                    value={group.name}
+                                    onChange={(e) => updateGroup(idx, { ...group, name: e.target.value })}
+                                    placeholder="Group name"
+                                />
+                                <input
+                                    className="input input-bordered input-xs w-32"
+                                    value={group.color}
+                                    onChange={(e) => updateGroup(idx, { ...group, color: e.target.value })}
+                                    placeholder="text-color-500"
+                                />
+                                <label className="flex items-center gap-1 text-xs">
+                                    <input
+                                        type="checkbox"
+                                        checked={group.isFull}
+                                        onChange={(e) => updateGroup(idx, { ...group, isFull: e.target.checked })}
+                                    />
+                                    Full
+                                </label>
+                                <button
+                                    className="btn btn-xs btn-error"
+                                    onClick={() => setRouteGroups(arr => arr.filter((_, i) => i !== idx))}
+                                >
+                                    Remove
+                                </button>
+                            </div>
+                            <textarea
+                                className="textarea textarea-bordered w-full text-xs h-16"
+                                value={group.codes.join(', ')}
+                                onChange={(e) => updateGroup(idx, { ...group, codes: e.target.value.split(',').map(c => c.trim().toUpperCase()).filter(Boolean) })}
+                                placeholder="Codes, separated by comma"
+                            />
+                        </div>
+                    ))}
+                    <button
+                        className="btn btn-sm mt-2"
+                        onClick={() => setRouteGroups([...routeGroups, { name: 'New Group', codes: [], isFull: false, color: 'text-white' }])}
+                    >
+                        <Icon name="plus" className="w-4 h-4 mr-1" />
+                        Add Group
+                    </button>
+                </section>
+                <section className="card bg-base-100 shadow p-4">
+                    <h4 className="card-title text-lg mb-2">Ignored Calendar Patterns</h4>
+                    <textarea
+                        className="textarea textarea-bordered w-full text-xs h-24"
+                        value={ignoredPatterns.join('\n')}
+                        onChange={handlePatternChange}
+                        placeholder="One pattern per line"
+                    />
+                </section>
+            </div>
+            <div className="modal-action">
+                <button className="btn btn-outline mr-auto" onClick={resetSettings}>Reset Defaults</button>
+                <button className="btn" onClick={onClose}>Close</button>
+            </div>
+        </Modal>
+    );
+}

--- a/types/schedule.ts
+++ b/types/schedule.ts
@@ -1,0 +1,30 @@
+export interface Trip {
+    ID: string;
+    Start_Time?: string;
+    End_Time?: string;
+    Driver1?: string;
+    Contractor?: string;
+    Punctuality?: string;
+    Calendar_Name?: string;
+    Order_Value?: string;
+    isAssigned?: boolean;
+    fromLeftIndex?: number; // For right trips, to track origin in left
+}
+
+export interface RouteGroup {
+    name: string;
+    codes: string[];
+    isFull: boolean;
+    color: string;
+}
+
+export interface TimeSettings {
+    lateEndHour: number;
+    earlyStartHour: number;
+    earlyEndHour: number;
+    lateStartHour: number;
+    restMessage: string;
+    earlyMessage: string;
+    enableRestWarning: boolean;
+    enableEarlyWarning: boolean;
+}


### PR DESCRIPTION
## Summary
- split schedule-tool page into reusable components for stats, sidebar notes, and settings modal
- centralize schedule types for trips, route groups, and time settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Type error in components/OrderDetailModal.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68959acc6ce08324b5c6de84c63cf627