### PR TITLE
Load pdf.js viewer CSS from CDN and expose PDF editor

### DIFF
--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -34,7 +34,10 @@ export default function Navbar() {
   const navGroups: NavGroup[] = useMemo(() => [
     {
       label: 'General',
-      links: [{ href: '/', icon: 'house', label: 'Home' }],
+      links: [
+        { href: '/', icon: 'house', label: 'Home' },
+        { href: '/pdf-editor', icon: 'pen', label: 'PDF Editor' },
+      ],
     },
     {
       label: 'Driver Control',

--- a/pages/pdf-editor.tsx
+++ b/pages/pdf-editor.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import Head from 'next/head';
 import Layout from '../components/Layout';
 import {
   FileUp,
@@ -17,7 +18,6 @@ import {
 import { PDFDocument, rgb, StandardFonts } from 'pdf-lib';
 // @ts-ignore - pdfjs-dist types are optional
 import * as pdfjsLib from 'pdfjs-dist';
-import 'pdfjs-dist/web/pdf_viewer.css';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.6.82/pdf.worker.min.js`;
 
@@ -811,6 +811,12 @@ export default function PdfEditorPage() {
 
   return (
     <Layout title="PDF Editor" fullWidth>
+      <Head>
+        <link
+          rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.6.82/pdf_viewer.min.css"
+        />
+      </Head>
       <div className="border-b bg-base-100 sticky top-0 z-40">
         <div className="px-4 py-3 flex items-center gap-3">
           <Button onClick={() => fileInputRef.current?.click()}>


### PR DESCRIPTION
## Summary
- Prevent missing image errors by loading pdf.js viewer styles from CDN
- Link PDF editor page from navigation menu for quick access

## Testing
- `npm run build` *(fails: Type error: Type '{ children: Element; title: string; icon: string; }' is not assignable to type 'IntrinsicAttributes & { title: string; children: ReactNode; }'.)*

------
https://chatgpt.com/codex/tasks/task_e_689993753098832488bac9699f1e2a70