### PR TITLE
feat: allow selecting date range for daily driver stats

### DIFF
--- a/pages/daily-driver-stats.tsx
+++ b/pages/daily-driver-stats.tsx
@@ -22,22 +22,40 @@ function formatDate(d: Date): string {
 }
 
 export default function DailyDriverStats() {
+  const today = new Date();
+  const defaultEnd = formatDate(today);
+  const defaultStart = formatDate(new Date(today.getTime() - 6 * 24 * 60 * 60 * 1000));
+
+  const [start, setStart] = useState(defaultStart);
+  const [end, setEnd] = useState(defaultEnd);
   const [data, setData] = useState<StatsResponse | null>(null);
 
   useEffect(() => {
-    const end = formatDate(new Date());
-    const startDate = new Date();
-    startDate.setDate(startDate.getDate() - 6);
-    const start = formatDate(startDate);
     fetch(`/api/monthly-driver-stats?start=${start}&end=${end}`)
       .then((res) => (res.ok ? res.json() : Promise.reject()))
       .then(setData)
       .catch(() => setData(null));
-  }, []);
+  }, [start, end]);
 
   return (
     <Layout title="Daily Driver Stats" fullWidth>
-      <div className="p-4 overflow-auto">
+      <div className="p-4 overflow-auto space-y-2">
+        <div className="flex flex-wrap gap-2 items-center">
+          <input
+            type="date"
+            value={start}
+            onChange={(e) => setStart(e.target.value)}
+            className="px-2 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white rounded-lg border border-gray-300 dark:border-gray-600 focus:ring-1 focus:ring-blue-500"
+            aria-label="Start date"
+          />
+          <input
+            type="date"
+            value={end}
+            onChange={(e) => setEnd(e.target.value)}
+            className="px-2 py-1 text-sm bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white rounded-lg border border-gray-300 dark:border-gray-600 focus:ring-1 focus:ring-blue-500"
+            aria-label="End date"
+          />
+        </div>
         {data ? (
           <table className="w-full text-center border-collapse text-xs">
             <thead>


### PR DESCRIPTION
## Summary
- allow selecting custom start and end dates for daily driver stats
- fetch data when chosen dates change

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899ac4e5b188324aa23b069bd5ff909