### PR TITLE
Handle non-array notifications

### DIFF
--- a/components/ToastNotifications.tsx
+++ b/components/ToastNotifications.tsx
@@ -15,7 +15,10 @@ export default function ToastNotifications() {
     const res = await fetch('/api/notifications?type=task');
     if (res.ok) {
       const data = await res.json();
-      setItems(data.items as Notification[]);
+      const notifications = Array.isArray(data.items) ? data.items : [];
+      setItems(notifications as Notification[]);
+    } else {
+      setItems([]);
     }
   };
 

--- a/components/UploadHistory.tsx
+++ b/components/UploadHistory.tsx
@@ -23,7 +23,8 @@ export default function UploadHistory() {
         throw new Error('Failed to fetch upload history');
       }
       const data = await res.json();
-      setItems(data.items as Item[]);
+      const items = Array.isArray(data.items) ? data.items : [];
+      setItems(items as Item[]);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred');
     } finally {

--- a/lib/useNotifications.ts
+++ b/lib/useNotifications.ts
@@ -16,7 +16,10 @@ export default function useNotifications(autoLoad: boolean = true) {
     const res = await fetch('/api/notifications');
     if (res.ok) {
       const data = await res.json();
-      setItems(data.items as Notification[]);
+      const notifications = Array.isArray(data.items) ? data.items : [];
+      setItems(notifications as Notification[]);
+    } else {
+      setItems([]);
     }
     setLoading(false);
   }, []);


### PR DESCRIPTION
## Summary
- Safely parse notifications API responses to ensure array shape
- Prevent runtime errors in ToastNotifications and UploadHistory when server returns single object or null
- Harden notification hook with array guard and fallback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c2c0f16f08324ac5588001d172f2f