### PR TITLE
feat: init duckdb demo

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+out
+.env
+*.duckdb

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# DuckDB Demo
+
+## Установка
+```bash
+npm i
+```
+
+## Запуск
+```bash
+npm run dev
+```
+
+- Главная страница: `/` — статус подключения к БД
+- Страница настроек: `/settings`
+
+### Пример настроек
+- Mock: `engine = mock`
+- DuckDB: `engine = duckdb`, `duckdbPath = ./data/analytics.duckdb`

--- a/app/api/db/current/route.ts
+++ b/app/api/db/current/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { getSettings } from '@/lib/settings-store';
+
+export async function GET() {
+  const settings = await getSettings();
+  return NextResponse.json(settings);
+}

--- a/app/api/db/ping/route.ts
+++ b/app/api/db/ping/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { getSettings } from '@/lib/settings-store';
+import { getDbAdapter } from '@/lib/db/factory';
+
+export async function GET() {
+  const settings = await getSettings();
+  const adapter = getDbAdapter(settings);
+  const res = await adapter.ping();
+  return NextResponse.json({
+    engine: settings.engine,
+    connected: res.connected,
+    version: res.version,
+  });
+}

--- a/app/api/db/save/route.ts
+++ b/app/api/db/save/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { dbSettingsSchema } from '@/lib/schemas';
+import { saveSettings } from '@/lib/settings-store';
+import { ensureFile } from '@/lib/fs';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const settings = dbSettingsSchema.parse(body);
+    if (settings.engine === 'duckdb' && settings.duckdbPath) {
+      await ensureFile(settings.duckdbPath);
+    }
+    await saveSettings(settings);
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e.message }, { status: 400 });
+  }
+}

--- a/app/api/db/test/route.ts
+++ b/app/api/db/test/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { dbSettingsSchema } from '@/lib/schemas';
+import { getDbAdapter } from '@/lib/db/factory';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const settings = dbSettingsSchema.parse(body);
+    const adapter = getDbAdapter(settings);
+    const res = await adapter.ping();
+    return NextResponse.json({ ok: res.connected, version: res.version, error: res.error });
+  } catch (e: any) {
+    return NextResponse.json({ ok: false, error: e.message }, { status: 400 });
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply min-h-screen bg-gray-50;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,14 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'DuckDB Demo',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="p-4">{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,14 @@
+export default async function Home() {
+  const res = await fetch('http://localhost:3000/api/db/ping', { cache: 'no-store' });
+  const data = await res.json();
+  return (
+    <main className="max-w-sm mx-auto">
+      <div className="border rounded p-4">
+        <h2 className="text-lg font-semibold mb-2">Статус подключения к БД</h2>
+        <p>Движок: {data.engine}</p>
+        <p>Подключено: {String(data.connected)}</p>
+        {data.version && <p>Версия: {data.version}</p>}
+      </div>
+    </main>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+
+type Engine = 'mock' | 'duckdb';
+
+export default function SettingsPage() {
+  const [engine, setEngine] = useState<Engine>('mock');
+  const [duckdbPath, setDuckdbPath] = useState('./data/analytics.duckdb');
+  const [message, setMessage] = useState<string | null>(null);
+
+  const loadCurrent = async () => {
+    const res = await fetch('/api/db/current');
+    const data = await res.json();
+    setEngine(data.engine);
+    if (data.duckdbPath) setDuckdbPath(data.duckdbPath);
+  };
+
+  const testConn = async () => {
+    const res = await fetch('/api/db/test', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ engine, duckdbPath }),
+    });
+    const data = await res.json();
+    if (data.ok) setMessage(`OK: ${data.version}`);
+    else setMessage(`Error: ${data.error}`);
+  };
+
+  const save = async () => {
+    const res = await fetch('/api/db/save', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ engine, duckdbPath }),
+    });
+    const data = await res.json();
+    if (data.ok) setMessage('Сохранено');
+    else setMessage(`Error: ${data.error}`);
+  };
+
+  return (
+    <main className="max-w-lg mx-auto space-y-4">
+      <h1 className="text-xl font-semibold">Настройки</h1>
+      <div className="space-y-2">
+        <Label>Движок базы данных</Label>
+        <RadioGroup value={engine} onValueChange={v => setEngine(v as Engine)} className="flex space-x-4">
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="mock" id="mock" />
+            <Label htmlFor="mock">mock</Label>
+          </div>
+          <div className="flex items-center space-x-2">
+            <RadioGroupItem value="duckdb" id="duckdb" />
+            <Label htmlFor="duckdb">duckdb</Label>
+          </div>
+        </RadioGroup>
+      </div>
+      {engine === 'duckdb' && (
+        <div className="space-y-2">
+          <Label htmlFor="duckdbPath">Путь к файлу</Label>
+          <Input id="duckdbPath" value={duckdbPath} onChange={e => setDuckdbPath(e.target.value)} />
+        </div>
+      )}
+      <div className="flex space-x-2">
+        <Button type="button" onClick={testConn}>Проверить подключение</Button>
+        <Button type="button" onClick={save} variant="secondary">Сохранить</Button>
+        <Button type="button" onClick={loadCurrent} variant="outline">Загрузить текущие</Button>
+      </div>
+      {message && <p>{message}</p>}
+    </main>
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 disabled:opacity-50 disabled:pointer-events-none',
+  {
+    variants: {
+      variant: {
+        default: 'bg-blue-600 text-white hover:bg-blue-600/90',
+        secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-200/90',
+        outline: 'border border-gray-300 hover:bg-gray-100',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, ...props }, ref) => (
+    <button ref={ref} className={cn(buttonVariants({ variant, size, className }))} {...props} />
+  )
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, ...props }, ref) => (
+  <input
+    ref={ref}
+    className={cn('flex h-10 w-full rounded-md border px-3 py-2 text-sm', className)}
+    {...props}
+  />
+));
+Input.displayName = 'Input';
+
+export { Input };

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(({ className, ...props }, ref) => (
+  <label ref={ref} className={cn('text-sm font-medium', className)} {...props} />
+));
+Label.displayName = 'Label';
+
+export { Label };

--- a/components/ui/radio-group.tsx
+++ b/components/ui/radio-group.tsx
@@ -1,0 +1,34 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+interface RadioGroupProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: string;
+  onValueChange?: (value: string) => void;
+}
+
+function RadioGroup({ className, value, onValueChange, children, ...props }: RadioGroupProps) {
+  return (
+    <div className={cn('flex gap-2', className)} {...props}>
+      {React.Children.map(children, (child) => {
+        if (!React.isValidElement(child)) return child;
+        return React.cloneElement(child, {
+          checked: child.props.value === value,
+          onChange: () => onValueChange?.(child.props.value),
+        });
+      })}
+    </div>
+  );
+}
+
+interface RadioGroupItemProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  value: string;
+}
+
+const RadioGroupItem = React.forwardRef<HTMLInputElement, RadioGroupItemProps>(
+  ({ className, ...props }, ref) => (
+    <input type="radio" ref={ref} className={cn('h-4 w-4', className)} {...props} />
+  )
+);
+RadioGroupItem.displayName = 'RadioGroupItem';
+
+export { RadioGroup, RadioGroupItem };

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,0 +1,1 @@
+analytics.duckdb

--- a/data/settings.json
+++ b/data/settings.json
@@ -1,0 +1,4 @@
+{
+  "engine": "mock",
+  "duckdbPath": "./data/analytics.duckdb"
+}

--- a/lib/db/adapters/duckdb.ts
+++ b/lib/db/adapters/duckdb.ts
@@ -1,0 +1,23 @@
+import Database from 'duckdb';
+import { DbAdapter, DbPingResult } from '../types';
+
+export function createDuckDbAdapter(path: string): DbAdapter {
+  const db = new Database(path);
+  return {
+    async ping(): Promise<DbPingResult> {
+      try {
+        const conn = db.connect();
+        const version: string = await new Promise((resolve, reject) => {
+          conn.all("SELECT version() AS version", (err, rows) => {
+            if (err) reject(err);
+            else resolve(rows[0].version as string);
+          });
+        });
+        conn.close();
+        return { connected: true, version };
+      } catch (e: any) {
+        return { connected: false, error: e.message };
+      }
+    },
+  };
+}

--- a/lib/db/adapters/mock.ts
+++ b/lib/db/adapters/mock.ts
@@ -1,0 +1,9 @@
+import { DbAdapter, DbPingResult } from '../types';
+
+export function createMockAdapter(): DbAdapter {
+  return {
+    async ping(): Promise<DbPingResult> {
+      return { connected: true, version: 'mock-1.0' };
+    },
+  };
+}

--- a/lib/db/factory.ts
+++ b/lib/db/factory.ts
@@ -1,0 +1,8 @@
+import { DbAdapter, DbSettings } from './types';
+import { createMockAdapter } from './adapters/mock';
+import { createDuckDbAdapter } from './adapters/duckdb';
+
+export function getDbAdapter(settings: DbSettings): DbAdapter {
+  if (settings.engine === 'mock') return createMockAdapter();
+  return createDuckDbAdapter(settings.duckdbPath ?? './data/analytics.duckdb');
+}

--- a/lib/db/types.ts
+++ b/lib/db/types.ts
@@ -1,0 +1,16 @@
+export type DbEngine = 'mock' | 'duckdb';
+
+export interface DbSettings {
+  engine: DbEngine;
+  duckdbPath?: string;
+}
+
+export interface DbPingResult {
+  connected: boolean;
+  version?: string;
+  error?: string;
+}
+
+export interface DbAdapter {
+  ping(): Promise<DbPingResult>;
+}

--- a/lib/fs.ts
+++ b/lib/fs.ts
@@ -1,0 +1,12 @@
+import { access, mkdir, writeFile } from 'fs/promises';
+import { constants } from 'fs';
+import { dirname } from 'path';
+
+export async function ensureFile(path: string) {
+  try {
+    await access(path, constants.F_OK);
+  } catch {
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, '');
+  }
+}

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const dbSettingsSchema = z
+  .object({
+    engine: z.enum(['mock', 'duckdb']),
+    duckdbPath: z.string().optional(),
+  })
+  .refine(
+    (data) => data.engine === 'mock' || !!data.duckdbPath,
+    { message: 'duckdbPath required for duckdb engine', path: ['duckdbPath'] }
+  );
+
+export type DbSettingsInput = z.infer<typeof dbSettingsSchema>;

--- a/lib/settings-store.ts
+++ b/lib/settings-store.ts
@@ -1,0 +1,37 @@
+import { readFile, writeFile } from 'fs/promises';
+import { DbSettings } from './db/types';
+import { ensureFile } from './fs';
+
+const SETTINGS_PATH = './data/settings.json';
+const defaultSettings: DbSettings = {
+  engine: 'mock',
+  duckdbPath: './data/analytics.duckdb',
+};
+
+let memory: DbSettings | null = null;
+
+async function loadFromFile(): Promise<DbSettings> {
+  try {
+    await ensureFile(SETTINGS_PATH);
+    const raw = await readFile(SETTINGS_PATH, 'utf-8');
+    return raw ? (JSON.parse(raw) as DbSettings) : defaultSettings;
+  } catch {
+    return defaultSettings;
+  }
+}
+
+export async function getSettings(): Promise<DbSettings> {
+  if (memory) return memory;
+  memory = await loadFromFile();
+  return memory;
+}
+
+export async function saveSettings(settings: DbSettings): Promise<void> {
+  memory = settings;
+  try {
+    await ensureFile(SETTINGS_PATH);
+    await writeFile(SETTINGS_PATH, JSON.stringify(settings, null, 2));
+  } catch {
+    // ignore file write errors
+  }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "duckdb-demo",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests\" && exit 0"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.0.0",
+    "duckdb": "^0.9.1",
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "tailwind-merge": "^1.14.0",
+    "tailwindcss": "3.4.1",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "14.1.0",
+    "postcss": "^8.4.31",
+    "typescript": "^5.2.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,8 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}', './lib/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: [],
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- setup Next.js app with DuckDB mock and real adapters
- add settings API and pages with Tailwind UI

## Testing
- `npm test`
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run build` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_689f1089f72083248779d59fb84b0404