### PR TITLE
fix Next.js config syntax for Node runtime

### DIFF
--- a/.next/trace
+++ b/.next/trace
@@ -1,1 +1,0 @@
-[{"name":"next-dev","duration":148497368,"timestamp":2487825270187,"id":1,"tags":{},"startTime":1755253695316,"traceId":"82f5ae01798387a2"}]

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,0 @@
-import type { NextConfig } from 'next';
-
-const nextConfig: NextConfig = {};
-
-export default nextConfig;


### PR DESCRIPTION
## Summary
- convert Next.js config to `next.config.mjs` with JSDoc types so Node can parse it
- remove stray `.next/trace` build artifact from source control

## Testing
- `npm test`
- `npm run lint`
- `npm run dev` (terminated after startup)


------
https://chatgpt.com/codex/tasks/task_e_689f3772a0b08324822f467d3d4bf2fa